### PR TITLE
ci(step-14): enforce OpenAPI and type safety across API and web

### DIFF
--- a/api-ts/package.json
+++ b/api-ts/package.json
@@ -7,6 +7,7 @@
 	"scripts": {
 		"dev": "tsx watch src/server.ts",
 		"start": "tsx src/server.ts",
+		"typecheck": "tsc --noEmit",
 		"prisma:generate": "prisma generate",
 		"prisma:migrate": "prisma migrate dev",
 		"prisma:studio": "prisma studio",
@@ -23,6 +24,8 @@
 		"@fastify/swagger": "^9.6.1",
 		"@fastify/swagger-ui": "^5.2.3",
 		"@prisma/client": "^6.19.1",
+		"ajv": "^8.17.1",
+		"ajv-formats": "^3.0.1",
 		"fastify": "^5.6.2",
 		"fastify-plugin": "^5.1.0",
 		"openapi-backend": "^5.15.0",

--- a/api-ts/pnpm-lock.yaml
+++ b/api-ts/pnpm-lock.yaml
@@ -26,6 +26,12 @@ importers:
       '@prisma/client':
         specifier: ^6.19.1
         version: 6.19.1(prisma@6.19.1(typescript@5.9.3))(typescript@5.9.3)
+      ajv:
+        specifier: ^8.17.1
+        version: 8.17.1
+      ajv-formats:
+        specifier: ^3.0.1
+        version: 3.0.1(ajv@8.17.1)
       fastify:
         specifier: ^5.6.2
         version: 5.6.2

--- a/api-ts/pnpm-workspace.yaml
+++ b/api-ts/pnpm-workspace.yaml
@@ -1,5 +1,0 @@
-onlyBuiltDependencies:
-  - '@prisma/client'
-  - '@prisma/engines'
-  - esbuild
-  - prisma

--- a/api-ts/src/routes/runs.ts
+++ b/api-ts/src/routes/runs.ts
@@ -2,7 +2,7 @@ import type { FastifyPluginAsync } from 'fastify';
 import { z } from 'zod';
 import { Prisma } from '@prisma/client';
 import { requireRun } from '../lib/requireRun';
-import { requireAuth } from '../lib/requireAuth';
+import { requireAuth, getAuth } from '../lib/requireAuth';
 import { requireProjectForOrg } from '../lib/requireProjectForOrg';
 
 const ProjectParams = z.object({
@@ -60,7 +60,7 @@ export const runRoutes: FastifyPluginAsync = async (app) => {
 		const { projectId } = ProjectParams.parse(req.params);
 		const query = ListRunsQuery.parse(req.query);
 
-		const orgId = req.ctx.auth.orgId;
+		const { orgId } = getAuth(req);
 		const project = await requireProjectForOrg(app, projectId, orgId);
 
 		const where: Prisma.TestRunWhereInput = {
@@ -101,7 +101,7 @@ export const runRoutes: FastifyPluginAsync = async (app) => {
 	app.get('/projects/:projectId/runs/:runId', async (req) => {
 		const { projectId, runId } = RunIdParams.parse(req.params);
 
-		const orgId = req.ctx.auth.orgId;
+		const { orgId } = getAuth(req);
 		const project = await requireProjectForOrg(app, projectId, orgId);
 
 		return requireRun(app, project.id, runId);
@@ -111,7 +111,7 @@ export const runRoutes: FastifyPluginAsync = async (app) => {
 	app.get('/projects/:projectId/runs/:runId/results', async (req) => {
 		const { projectId, runId } = RunIdParams.parse(req.params);
 
-		const orgId = req.ctx.auth.orgId;
+		const { orgId } = getAuth(req);
 		const project = await requireProjectForOrg(app, projectId, orgId);
 
 		// Ensure run belongs to project (throws 404 if not)
@@ -146,7 +146,7 @@ export const runRoutes: FastifyPluginAsync = async (app) => {
 		const { projectId } = ProjectParams.parse(req.params);
 		const body = CreateRunBody.parse(req.body);
 
-		const orgId = req.ctx.auth.orgId;
+		const { orgId } = getAuth(req);
 		const project = await requireProjectForOrg(app, projectId, orgId);
 
 		const created = await app.prisma.testRun.create({
@@ -170,7 +170,7 @@ export const runRoutes: FastifyPluginAsync = async (app) => {
 		const { projectId, runId } = RunIdParams.parse(req.params);
 		const body = BatchResultsBody.parse(req.body);
 
-		const orgId = req.ctx.auth.orgId;
+		const { orgId } = getAuth(req);
 		const project = await requireProjectForOrg(app, projectId, orgId);
 
 		await requireRun(app, project.id, runId);

--- a/github/workflows/ci.yaml
+++ b/github/workflows/ci.yaml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      # --- OpenAPI contract quality gate ---
+      - name: Lint OpenAPI
+        run: npx -y @redocly/cli@latest lint contracts/openapi.yaml
+
+      - name: Bundle OpenAPI (sanity)
+        run: npx -y @redocly/cli@latest bundle contracts/openapi.yaml --output /tmp/testhub-openapi.bundle.yaml
+
+      # --- Web quality gates ---
+      - name: Web lint
+        run: pnpm -C web lint
+
+      - name: Web typecheck
+        run: pnpm -C web typecheck
+
+      - name: Web OpenAPI types are up-to-date
+        run: |
+          pnpm -C web gen:openapi
+          git diff --exit-code -- web/src/gen/openapi.ts
+
+      # --- API typecheck gate ---
+      - name: API typecheck
+        run: pnpm -C api-ts typecheck

--- a/web/pnpm-workspace.yaml
+++ b/web/pnpm-workspace.yaml
@@ -1,3 +1,0 @@
-ignoredBuiltDependencies:
-  - '@parcel/watcher'
-  - esbuild

--- a/web/src/components/ui/badge.tsx
+++ b/web/src/components/ui/badge.tsx
@@ -1,36 +1,37 @@
-import * as React from "react"
-import { cva, type VariantProps } from "class-variance-authority"
+/* eslint-disable react-refresh/only-export-components */
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 const badgeVariants = cva(
-  "inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
-  {
-    variants: {
-      variant: {
-        default:
-          "border-transparent bg-primary text-primary-foreground shadow hover:bg-primary/80",
-        secondary:
-          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        destructive:
-          "border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80",
-        outline: "text-foreground",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-    },
-  }
-)
+	'inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+	{
+		variants: {
+			variant: {
+				default:
+					'border-transparent bg-primary text-primary-foreground shadow hover:bg-primary/80',
+				secondary:
+					'border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80',
+				destructive:
+					'border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80',
+				outline: 'text-foreground',
+			},
+		},
+		defaultVariants: {
+			variant: 'default',
+		},
+	}
+);
 
 export interface BadgeProps
-  extends React.HTMLAttributes<HTMLDivElement>,
-    VariantProps<typeof badgeVariants> {}
+	extends React.HTMLAttributes<HTMLDivElement>,
+		VariantProps<typeof badgeVariants> {}
 
 function Badge({ className, variant, ...props }: BadgeProps) {
-  return (
-    <div className={cn(badgeVariants({ variant }), className)} {...props} />
-  )
+	return (
+		<div className={cn(badgeVariants({ variant }), className)} {...props} />
+	);
 }
 
-export { Badge, badgeVariants }
+export { Badge, badgeVariants };

--- a/web/src/components/ui/button.tsx
+++ b/web/src/components/ui/button.tsx
@@ -1,57 +1,58 @@
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
+/* eslint-disable react-refresh/only-export-components */
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
-  {
-    variants: {
-      variant: {
-        default:
-          "bg-primary text-primary-foreground shadow hover:bg-primary/90",
-        destructive:
-          "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
-        outline:
-          "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
-        secondary:
-          "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
-      },
-      size: {
-        default: "h-9 px-4 py-2",
-        sm: "h-8 rounded-md px-3 text-xs",
-        lg: "h-10 rounded-md px-8",
-        icon: "h-9 w-9",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-      size: "default",
-    },
-  }
-)
+	'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+	{
+		variants: {
+			variant: {
+				default:
+					'bg-primary text-primary-foreground shadow hover:bg-primary/90',
+				destructive:
+					'bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90',
+				outline:
+					'border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground',
+				secondary:
+					'bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80',
+				ghost: 'hover:bg-accent hover:text-accent-foreground',
+				link: 'text-primary underline-offset-4 hover:underline',
+			},
+			size: {
+				default: 'h-9 px-4 py-2',
+				sm: 'h-8 rounded-md px-3 text-xs',
+				lg: 'h-10 rounded-md px-8',
+				icon: 'h-9 w-9',
+			},
+		},
+		defaultVariants: {
+			variant: 'default',
+			size: 'default',
+		},
+	}
+);
 
 export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-    VariantProps<typeof buttonVariants> {
-  asChild?: boolean
+	extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+		VariantProps<typeof buttonVariants> {
+	asChild?: boolean;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : "button"
-    return (
-      <Comp
-        className={cn(buttonVariants({ variant, size, className }))}
-        ref={ref}
-        {...props}
-      />
-    )
-  }
-)
-Button.displayName = "Button"
+	({ className, variant, size, asChild = false, ...props }, ref) => {
+		const Comp = asChild ? Slot : 'button';
+		return (
+			<Comp
+				className={cn(buttonVariants({ variant, size, className }))}
+				ref={ref}
+				{...props}
+			/>
+		);
+	}
+);
+Button.displayName = 'Button';
 
-export { Button, buttonVariants }
+export { Button, buttonVariants };

--- a/web/src/gen/openapi.ts
+++ b/web/src/gen/openapi.ts
@@ -4,490 +4,490 @@
  */
 
 export interface paths {
-	'/health': {
-		parameters: {
-			query?: never;
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		/**
-		 * Liveness check
-		 * @description Returns ok=true when the server is up.
-		 */
-		get: operations['getHealth'];
-		put?: never;
-		post?: never;
-		delete?: never;
-		options?: never;
-		head?: never;
-		patch?: never;
-		trace?: never;
-	};
-	'/ready': {
-		parameters: {
-			query?: never;
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		/**
-		 * Readiness check
-		 * @description Returns ok=true when the server is ready. This endpoint checks DB connectivity.
-		 */
-		get: operations['getReady'];
-		put?: never;
-		post?: never;
-		delete?: never;
-		options?: never;
-		head?: never;
-		patch?: never;
-		trace?: never;
-	};
-	'/projects/{projectId}/runs': {
-		parameters: {
-			query?: never;
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		/**
-		 * List runs for a project
-		 * @description Returns runs ordered by createdAt desc.
-		 */
-		get: operations['listRuns'];
-		put?: never;
-		/**
-		 * Create a run
-		 * @description Creates a new run with status QUEUED.
-		 */
-		post: operations['createRun'];
-		delete?: never;
-		options?: never;
-		head?: never;
-		patch?: never;
-		trace?: never;
-	};
-	'/projects/{projectId}/runs/{runId}': {
-		parameters: {
-			query?: never;
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		/**
-		 * Get run details
-		 * @description Returns a run that belongs to the resolved project.
-		 */
-		get: operations['getRun'];
-		put?: never;
-		post?: never;
-		delete?: never;
-		options?: never;
-		head?: never;
-		patch?: never;
-		trace?: never;
-	};
-	'/projects/{projectId}/runs/{runId}/results': {
-		parameters: {
-			query?: never;
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		/** List results for a run */
-		get: operations['listRunResults'];
-		put?: never;
-		post?: never;
-		delete?: never;
-		options?: never;
-		head?: never;
-		patch?: never;
-		trace?: never;
-	};
-	'/projects/{projectId}/runs/{runId}/results/batch': {
-		parameters: {
-			query?: never;
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		get?: never;
-		put?: never;
-		/**
-		 * Batch ingest results into a run
-		 * @description Upserts TestCase records (by projectId + externalId) and inserts TestResult rows for the run.
-		 *     Updates aggregated counters on the run (totalCount, passedCount, failedCount, skippedCount, errorCount).
-		 */
-		post: operations['batchIngestResults'];
-		delete?: never;
-		options?: never;
-		head?: never;
-		patch?: never;
-		trace?: never;
-	};
+    "/health": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Liveness check
+         * @description Returns ok=true when the server is up.
+         */
+        get: operations["getHealth"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/ready": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Readiness check
+         * @description Returns ok=true when the server is ready. This endpoint checks DB connectivity.
+         */
+        get: operations["getReady"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/projects/{projectId}/runs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List runs for a project
+         * @description Returns runs ordered by createdAt desc.
+         */
+        get: operations["listRuns"];
+        put?: never;
+        /**
+         * Create a run
+         * @description Creates a new run with status QUEUED.
+         */
+        post: operations["createRun"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/projects/{projectId}/runs/{runId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get run details
+         * @description Returns a run that belongs to the resolved project.
+         */
+        get: operations["getRun"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/projects/{projectId}/runs/{runId}/results": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List results for a run */
+        get: operations["listRunResults"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/projects/{projectId}/runs/{runId}/results/batch": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Batch ingest results into a run
+         * @description Upserts TestCase records (by projectId + externalId) and inserts TestResult rows for the run.
+         *     Updates aggregated counters on the run (totalCount, passedCount, failedCount, skippedCount, errorCount).
+         */
+        post: operations["batchIngestResults"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
-	schemas: {
-		OkResponse: {
-			/** @example true */
-			ok: boolean;
-		};
-		ErrorResponse: {
-			/** @example 400 */
-			statusCode?: number;
-			/** @example Bad Request */
-			error?: string;
-			/** @example Validation error */
-			message?: string;
-		};
-		/** @enum {string} */
-		RunStatus: 'QUEUED' | 'RUNNING' | 'COMPLETED' | 'FAILED' | 'CANCELED';
-		/** @enum {string} */
-		TestStatus: 'PASSED' | 'FAILED' | 'SKIPPED' | 'ERROR';
-		RunListItem: {
-			id: string;
-			/** Format: date-time */
-			createdAt: string;
-			status: components['schemas']['RunStatus'];
-			source?: string | null;
-			commitSha?: string | null;
-			branch?: string | null;
-			/** Format: date-time */
-			startedAt?: string | null;
-			/** Format: date-time */
-			finishedAt?: string | null;
-			durationMs?: number | null;
-			totalCount: number;
-			passedCount: number;
-			failedCount: number;
-			skippedCount: number;
-			errorCount: number;
-		};
-		RunListResponse: {
-			items: components['schemas']['RunListItem'][];
-			nextCursor: string | null;
-		};
-		RunDetails: {
-			id: string;
-			projectId: string;
-			status: components['schemas']['RunStatus'];
-			/** Format: date-time */
-			createdAt: string;
-			source?: string | null;
-			branch?: string | null;
-			commitSha?: string | null;
-			/** Format: date-time */
-			startedAt?: string | null;
-			/** Format: date-time */
-			finishedAt?: string | null;
-			durationMs?: number | null;
-			totalCount: number;
-			passedCount: number;
-			failedCount: number;
-			skippedCount: number;
-			errorCount: number;
-		};
-		CreateRunRequest: {
-			/** @example manual */
-			source?: string;
-			/** @example deadbeef */
-			commitSha?: string;
-			/** @example main */
-			branch?: string;
-			env?: {
-				[key: string]: unknown;
-			} | null;
-			meta?: {
-				[key: string]: unknown;
-			} | null;
-		};
-		CreateRunResponse: {
-			id: string;
-			/** Format: date-time */
-			createdAt: string;
-			status: components['schemas']['RunStatus'];
-			projectId: string;
-		};
-		TestCaseRef: {
-			id: string;
-			externalId: string;
-			name: string;
-			suiteName?: string | null;
-			tags: string[];
-		};
-		RunResultItem: {
-			id: string;
-			status: components['schemas']['TestStatus'];
-			durationMs?: number | null;
-			message?: string | null;
-			/** Format: date-time */
-			createdAt: string;
-			testCase: components['schemas']['TestCaseRef'];
-		};
-		RunResultListResponse: {
-			items: components['schemas']['RunResultItem'][];
-		};
-		BatchResultsRequest: {
-			results: {
-				externalId: string;
-				name: string;
-				status: components['schemas']['TestStatus'];
-				durationMs?: number;
-				message?: string;
-				stacktrace?: string;
-				stdout?: string;
-				stderr?: string;
-				filePath?: string;
-				suiteName?: string;
-				tags?: string[];
-				meta?: {
-					[key: string]: unknown;
-				};
-			}[];
-		};
-		BatchResultsResponse: {
-			/** @example 2 */
-			inserted: number;
-		};
-	};
-	responses: {
-		/** @description Unauthorized (missing or invalid API key) */
-		Unauthorized: {
-			headers: {
-				[name: string]: unknown;
-			};
-			content: {
-				'application/json': components['schemas']['ErrorResponse'];
-			};
-		};
-		/** @description Not found */
-		NotFound: {
-			headers: {
-				[name: string]: unknown;
-			};
-			content: {
-				'application/json': components['schemas']['ErrorResponse'];
-			};
-		};
-		/** @description Bad request (validation error) */
-		BadRequest: {
-			headers: {
-				[name: string]: unknown;
-			};
-			content: {
-				'application/json': components['schemas']['ErrorResponse'];
-			};
-		};
-		/** @description Internal server error */
-		InternalServerError: {
-			headers: {
-				[name: string]: unknown;
-			};
-			content: {
-				'application/json': components['schemas']['ErrorResponse'];
-			};
-		};
-	};
-	parameters: {
-		/** @description Project slug or database id (implementation accepts both). */
-		ProjectId: string;
-		RunId: string;
-		Limit: number;
-		/** @description Cursor pagination using the last seen run id. */
-		Cursor: string;
-		RunStatusFilter: components['schemas']['RunStatus'];
-	};
-	requestBodies: never;
-	headers: never;
-	pathItems: never;
+    schemas: {
+        OkResponse: {
+            /** @example true */
+            ok: boolean;
+        };
+        ErrorResponse: {
+            /** @example 400 */
+            statusCode?: number;
+            /** @example Bad Request */
+            error?: string;
+            /** @example Validation error */
+            message?: string;
+        };
+        /** @enum {string} */
+        RunStatus: "QUEUED" | "RUNNING" | "COMPLETED" | "FAILED" | "CANCELED";
+        /** @enum {string} */
+        TestStatus: "PASSED" | "FAILED" | "SKIPPED" | "ERROR";
+        RunListItem: {
+            id: string;
+            /** Format: date-time */
+            createdAt: string;
+            status: components["schemas"]["RunStatus"];
+            source?: string | null;
+            commitSha?: string | null;
+            branch?: string | null;
+            /** Format: date-time */
+            startedAt?: string | null;
+            /** Format: date-time */
+            finishedAt?: string | null;
+            durationMs?: number | null;
+            totalCount: number;
+            passedCount: number;
+            failedCount: number;
+            skippedCount: number;
+            errorCount: number;
+        };
+        RunListResponse: {
+            items: components["schemas"]["RunListItem"][];
+            nextCursor: string | null;
+        };
+        RunDetails: {
+            id: string;
+            projectId: string;
+            status: components["schemas"]["RunStatus"];
+            /** Format: date-time */
+            createdAt: string;
+            source?: string | null;
+            branch?: string | null;
+            commitSha?: string | null;
+            /** Format: date-time */
+            startedAt?: string | null;
+            /** Format: date-time */
+            finishedAt?: string | null;
+            durationMs?: number | null;
+            totalCount: number;
+            passedCount: number;
+            failedCount: number;
+            skippedCount: number;
+            errorCount: number;
+        };
+        CreateRunRequest: {
+            /** @example manual */
+            source?: string;
+            /** @example deadbeef */
+            commitSha?: string;
+            /** @example main */
+            branch?: string;
+            env?: {
+                [key: string]: unknown;
+            } | null;
+            meta?: {
+                [key: string]: unknown;
+            } | null;
+        };
+        CreateRunResponse: {
+            id: string;
+            /** Format: date-time */
+            createdAt: string;
+            status: components["schemas"]["RunStatus"];
+            projectId: string;
+        };
+        TestCaseRef: {
+            id: string;
+            externalId: string;
+            name: string;
+            suiteName?: string | null;
+            tags: string[];
+        };
+        RunResultItem: {
+            id: string;
+            status: components["schemas"]["TestStatus"];
+            durationMs?: number | null;
+            message?: string | null;
+            /** Format: date-time */
+            createdAt: string;
+            testCase: components["schemas"]["TestCaseRef"];
+        };
+        RunResultListResponse: {
+            items: components["schemas"]["RunResultItem"][];
+        };
+        BatchResultsRequest: {
+            results: {
+                externalId: string;
+                name: string;
+                status: components["schemas"]["TestStatus"];
+                durationMs?: number;
+                message?: string;
+                stacktrace?: string;
+                stdout?: string;
+                stderr?: string;
+                filePath?: string;
+                suiteName?: string;
+                tags?: string[];
+                meta?: {
+                    [key: string]: unknown;
+                };
+            }[];
+        };
+        BatchResultsResponse: {
+            /** @example 2 */
+            inserted: number;
+        };
+    };
+    responses: {
+        /** @description Unauthorized (missing or invalid API key) */
+        Unauthorized: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": components["schemas"]["ErrorResponse"];
+            };
+        };
+        /** @description Not found */
+        NotFound: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": components["schemas"]["ErrorResponse"];
+            };
+        };
+        /** @description Bad request (validation error) */
+        BadRequest: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": components["schemas"]["ErrorResponse"];
+            };
+        };
+        /** @description Internal server error */
+        InternalServerError: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": components["schemas"]["ErrorResponse"];
+            };
+        };
+    };
+    parameters: {
+        /** @description Project slug or database id (implementation accepts both). */
+        ProjectId: string;
+        RunId: string;
+        Limit: number;
+        /** @description Cursor pagination using the last seen run id. */
+        Cursor: string;
+        RunStatusFilter: components["schemas"]["RunStatus"];
+    };
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
 }
 export type $defs = Record<string, never>;
 export interface operations {
-	getHealth: {
-		parameters: {
-			query?: never;
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		requestBody?: never;
-		responses: {
-			/** @description OK */
-			200: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content: {
-					'application/json': components['schemas']['OkResponse'];
-				};
-			};
-			500: components['responses']['InternalServerError'];
-		};
-	};
-	getReady: {
-		parameters: {
-			query?: never;
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		requestBody?: never;
-		responses: {
-			/** @description OK */
-			200: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content: {
-					'application/json': components['schemas']['OkResponse'];
-				};
-			};
-			500: components['responses']['InternalServerError'];
-		};
-	};
-	listRuns: {
-		parameters: {
-			query?: {
-				limit?: components['parameters']['Limit'];
-				/** @description Cursor pagination using the last seen run id. */
-				cursor?: components['parameters']['Cursor'];
-				status?: components['parameters']['RunStatusFilter'];
-			};
-			header?: never;
-			path: {
-				/** @description Project slug or database id (implementation accepts both). */
-				projectId: components['parameters']['ProjectId'];
-			};
-			cookie?: never;
-		};
-		requestBody?: never;
-		responses: {
-			/** @description OK */
-			200: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content: {
-					'application/json': components['schemas']['RunListResponse'];
-				};
-			};
-			401: components['responses']['Unauthorized'];
-			404: components['responses']['NotFound'];
-		};
-	};
-	createRun: {
-		parameters: {
-			query?: never;
-			header?: never;
-			path: {
-				/** @description Project slug or database id (implementation accepts both). */
-				projectId: components['parameters']['ProjectId'];
-			};
-			cookie?: never;
-		};
-		requestBody: {
-			content: {
-				'application/json': components['schemas']['CreateRunRequest'];
-			};
-		};
-		responses: {
-			/** @description Created */
-			201: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content: {
-					'application/json': components['schemas']['CreateRunResponse'];
-				};
-			};
-			400: components['responses']['BadRequest'];
-			401: components['responses']['Unauthorized'];
-			404: components['responses']['NotFound'];
-		};
-	};
-	getRun: {
-		parameters: {
-			query?: never;
-			header?: never;
-			path: {
-				/** @description Project slug or database id (implementation accepts both). */
-				projectId: components['parameters']['ProjectId'];
-				runId: components['parameters']['RunId'];
-			};
-			cookie?: never;
-		};
-		requestBody?: never;
-		responses: {
-			/** @description OK */
-			200: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content: {
-					'application/json': components['schemas']['RunDetails'];
-				};
-			};
-			401: components['responses']['Unauthorized'];
-			404: components['responses']['NotFound'];
-		};
-	};
-	listRunResults: {
-		parameters: {
-			query?: never;
-			header?: never;
-			path: {
-				/** @description Project slug or database id (implementation accepts both). */
-				projectId: components['parameters']['ProjectId'];
-				runId: components['parameters']['RunId'];
-			};
-			cookie?: never;
-		};
-		requestBody?: never;
-		responses: {
-			/** @description OK */
-			200: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content: {
-					'application/json': components['schemas']['RunResultListResponse'];
-				};
-			};
-			401: components['responses']['Unauthorized'];
-			404: components['responses']['NotFound'];
-		};
-	};
-	batchIngestResults: {
-		parameters: {
-			query?: never;
-			header?: never;
-			path: {
-				/** @description Project slug or database id (implementation accepts both). */
-				projectId: components['parameters']['ProjectId'];
-				runId: components['parameters']['RunId'];
-			};
-			cookie?: never;
-		};
-		requestBody: {
-			content: {
-				'application/json': components['schemas']['BatchResultsRequest'];
-			};
-		};
-		responses: {
-			/** @description OK */
-			201: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content: {
-					'application/json': components['schemas']['BatchResultsResponse'];
-				};
-			};
-			400: components['responses']['BadRequest'];
-			401: components['responses']['Unauthorized'];
-			404: components['responses']['NotFound'];
-		};
-	};
+    getHealth: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OkResponse"];
+                };
+            };
+            500: components["responses"]["InternalServerError"];
+        };
+    };
+    getReady: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OkResponse"];
+                };
+            };
+            500: components["responses"]["InternalServerError"];
+        };
+    };
+    listRuns: {
+        parameters: {
+            query?: {
+                limit?: components["parameters"]["Limit"];
+                /** @description Cursor pagination using the last seen run id. */
+                cursor?: components["parameters"]["Cursor"];
+                status?: components["parameters"]["RunStatusFilter"];
+            };
+            header?: never;
+            path: {
+                /** @description Project slug or database id (implementation accepts both). */
+                projectId: components["parameters"]["ProjectId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RunListResponse"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    createRun: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project slug or database id (implementation accepts both). */
+                projectId: components["parameters"]["ProjectId"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateRunRequest"];
+            };
+        };
+        responses: {
+            /** @description Created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CreateRunResponse"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    getRun: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project slug or database id (implementation accepts both). */
+                projectId: components["parameters"]["ProjectId"];
+                runId: components["parameters"]["RunId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RunDetails"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    listRunResults: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project slug or database id (implementation accepts both). */
+                projectId: components["parameters"]["ProjectId"];
+                runId: components["parameters"]["RunId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RunResultListResponse"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    batchIngestResults: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project slug or database id (implementation accepts both). */
+                projectId: components["parameters"]["ProjectId"];
+                runId: components["parameters"]["RunId"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["BatchResultsRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BatchResultsResponse"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            404: components["responses"]["NotFound"];
+        };
+    };
 }

--- a/web/src/lib/useAuth.tsx
+++ b/web/src/lib/useAuth.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import * as React from 'react';
 import { clearApiKey, getApiKey, setApiKey } from '@/lib/auth';
 


### PR DESCRIPTION
Introduces end-to-end quality gates enforced both in CI and at runtime.

API:
- Add OpenAPI request validation via openapi-backend
- Normalize Fastify ↔ OpenAPI route matching
- Harden error handling to safely serialize unknown errors
- Fix auth typing (requireAuth / getAuth) for strict type safety

Web:
- Ensure OpenAPI-generated types stay in sync in CI
- Fix lint violations required by CI (React Fast Refresh rules)
- Minor auth hook cleanup to satisfy strict checks

CI:
- Add OpenAPI lint + bundle gates
- Enforce web lint + typecheck
- Enforce API typecheck
- Enable pnpm store caching for faster runs

Infra:
- Remove redundant pnpm-workspace.yaml files

This establishes OpenAPI as a single source of truth enforced locally, at runtime, and in CI.