### PR TITLE
feat(step-16): Add query parameters support to listRuns()

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -140,6 +140,10 @@ export type CreateProjectRequest =
 export type UpdateProjectRequest =
 	components['schemas']['UpdateProjectRequest'];
 
+// Query types
+export type ListRunsQuery =
+	paths['/projects/{projectId}/runs']['get']['parameters']['query'];
+
 // ---------- Typed API functions ----------
 
 // Path aliases (OpenAPI paths)
@@ -195,9 +199,17 @@ export function deleteProject(projectId: string) {
 
 // ----- Runs -----
 
-export function listRuns(projectSlug: string) {
+export function listRuns(projectSlug: string, query?: Partial<ListRunsQuery>) {
 	type Res = ResponseBody<PathRuns, 'get', '200'>;
-	return apiFetch<Res>(`/projects/${encodeURIComponent(projectSlug)}/runs`);
+	const params = new URLSearchParams();
+	if (query?.limit) params.set('limit', String(query.limit));
+	if (query?.cursor) params.set('cursor', query.cursor);
+	if (query?.status) params.set('status', query.status);
+	const queryString = params.toString();
+	const path = `/projects/${encodeURIComponent(projectSlug)}/runs${
+		queryString ? `?${queryString}` : ''
+	}`;
+	return apiFetch<Res>(path);
 }
 
 export function createRun(projectSlug: string) {


### PR DESCRIPTION
- Export ListRunsQuery type from OpenAPI schema
- Update listRuns() to accept optional query parameters (limit, cursor, status)
- Build URL query string dynamically from provided parameters
- Enables frontend filtering by run status and pagination

RunsPage already passes these parameters but they weren't being used by the API client. Now filtering and pagination will work end-to-end.