### PR TITLE
feat(tests): add Tests explorer (list + filters + history)

### DIFF
--- a/api-ts/src/routes/tests.ts
+++ b/api-ts/src/routes/tests.ts
@@ -1,0 +1,158 @@
+import type { FastifyPluginAsync } from 'fastify';
+import { z } from 'zod';
+import { Prisma } from '@prisma/client';
+
+import { requireAuth, getAuth } from '../lib/requireAuth';
+import { requireProjectForOrg } from '../lib/requireProjectForOrg';
+
+const ProjectParams = z.object({
+	projectId: z.string().min(1), // slug or db id
+});
+
+const TestCaseParams = z.object({
+	projectId: z.string().min(1),
+	testCaseId: z.string().min(1),
+});
+
+const ListTestsQuery = z.object({
+	q: z.string().trim().min(1).optional(),
+	suite: z.string().trim().min(1).optional(),
+	status: z.enum(['PASSED', 'FAILED', 'SKIPPED', 'ERROR']).optional(),
+	limit: z.coerce.number().int().min(1).max(200).default(100),
+});
+
+const HistoryQuery = z.object({
+	limit: z.coerce.number().int().min(1).max(200).default(50),
+});
+
+export const testRoutes: FastifyPluginAsync = async (app) => {
+	// Auth guard for *all* routes in this plugin
+	app.addHook('preHandler', async (req) => {
+		requireAuth(req);
+	});
+
+	// List test cases (with last-seen status)
+	app.get('/projects/:projectId/tests', async (req) => {
+		const { projectId } = ProjectParams.parse(req.params);
+		const query = ListTestsQuery.parse(req.query);
+
+		const { orgId } = getAuth(req);
+		const project = await requireProjectForOrg(app, projectId, orgId);
+
+		const qLike = query.q ? `%${query.q}%` : undefined;
+		const suiteLike = query.suite ? `%${query.suite}%` : undefined;
+
+		const items = await app.prisma.$queryRaw<
+			Array<{
+				id: string;
+				externalId: string;
+				name: string;
+				suiteName: string | null;
+				filePath: string | null;
+				tags: string[];
+				createdAt: Date;
+				lastStatus: string | null;
+				lastSeenAt: Date | null;
+			}>
+		>(Prisma.sql`
+			WITH latest AS (
+				SELECT DISTINCT ON (tr."testCaseId")
+					tr."testCaseId",
+					tr.status,
+					tr."createdAt" AS "lastSeenAt"
+				FROM "TestResult" tr
+				JOIN "TestRun" r ON r.id = tr."runId"
+				WHERE r."projectId" = ${project.id}
+				ORDER BY tr."testCaseId", tr."createdAt" DESC
+			)
+			SELECT
+				tc.id,
+				tc."externalId",
+				tc.name,
+				tc."suiteName",
+				tc."filePath",
+				tc.tags,
+				tc."createdAt",
+				latest.status AS "lastStatus",
+				latest."lastSeenAt" AS "lastSeenAt"
+			FROM "TestCase" tc
+			LEFT JOIN latest ON latest."testCaseId" = tc.id
+			WHERE tc."projectId" = ${project.id}
+				AND (${qLike}::text IS NULL OR tc.name ILIKE ${qLike} OR tc."externalId" ILIKE ${qLike})
+				AND (${suiteLike}::text IS NULL OR COALESCE(tc."suiteName", '') ILIKE ${suiteLike})
+				AND (${query.status ?? null}::text IS NULL OR latest.status = ${query.status ?? null})
+			ORDER BY COALESCE(latest."lastSeenAt", tc."createdAt") DESC
+			LIMIT ${query.limit}
+		`);
+
+		return {
+			items: items.map((r) => ({
+				id: r.id,
+				externalId: r.externalId,
+				name: r.name,
+				suiteName: r.suiteName,
+				filePath: r.filePath,
+				tags: r.tags,
+				createdAt: r.createdAt.toISOString(),
+				lastStatus: r.lastStatus,
+				lastSeenAt: r.lastSeenAt ? r.lastSeenAt.toISOString() : null,
+			})),
+		};
+	});
+
+	// Execution history for a single test case
+	app.get('/projects/:projectId/tests/:testCaseId/history', async (req) => {
+		const { projectId, testCaseId } = TestCaseParams.parse(req.params);
+		const query = HistoryQuery.parse(req.query);
+
+		const { orgId } = getAuth(req);
+		const project = await requireProjectForOrg(app, projectId, orgId);
+
+		// Ensure testCase belongs to the project
+		const testCase = await app.prisma.testCase.findFirst({
+			where: { id: testCaseId, projectId: project.id },
+			select: { id: true },
+		});
+		if (!testCase) throw app.httpErrors.notFound('Test case not found');
+
+		const results = await app.prisma.testResult.findMany({
+			where: {
+				testCaseId,
+				run: { projectId: project.id },
+			},
+			orderBy: { createdAt: 'desc' },
+			take: query.limit,
+			select: {
+				id: true,
+				status: true,
+				durationMs: true,
+				createdAt: true,
+				run: {
+					select: {
+						id: true,
+						createdAt: true,
+						status: true,
+						branch: true,
+						commitSha: true,
+					},
+				},
+			},
+		});
+
+		return {
+			items: results.map((r) => ({
+				id: r.id,
+				status: r.status,
+				durationMs: r.durationMs ?? null,
+				createdAt: r.createdAt.toISOString(),
+				run: {
+					id: r.run.id,
+					createdAt: r.run.createdAt.toISOString(),
+					status: r.run.status,
+					branch: r.run.branch ?? null,
+					commitSha: r.run.commitSha ?? null,
+				},
+			})),
+		};
+	});
+};

--- a/api-ts/src/server.ts
+++ b/api-ts/src/server.ts
@@ -11,6 +11,7 @@ import { authPlugin } from './plugins/auth';
 import { healthRoutes } from './routes/health';
 import { runRoutes } from './routes/runs';
 import { projectRoutes } from './routes/projects';
+import { testRoutes } from './routes/tests';
 
 export function buildApp() {
 	const app = Fastify({ logger: true });
@@ -34,6 +35,7 @@ export function buildApp() {
 	app.register(healthRoutes);
 	app.register(runRoutes);
 	app.register(projectRoutes);
+	app.register(testRoutes);
 
 	// Central error handler so OpenAPI validation / httpErrors
 	// all return a consistent shape that matches ErrorResponse.
@@ -52,15 +54,15 @@ export function buildApp() {
 			typeof anyErr.message === 'string'
 				? anyErr.message
 				: statusCode >= 500
-				? 'Internal Server Error'
-				: 'Bad Request';
+					? 'Internal Server Error'
+					: 'Bad Request';
 
 		const errorName =
 			typeof anyErr.name === 'string'
 				? anyErr.name
 				: statusCode >= 500
-				? 'Internal Server Error'
-				: 'Bad Request';
+					? 'Internal Server Error'
+					: 'Bad Request';
 
 		reply.status(statusCode).send({
 			statusCode,

--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -309,6 +309,53 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
+  # ---------- Tests ----------
+
+  /projects/{projectId}/tests:
+    get:
+      tags: [Tests]
+      operationId: listTests
+      summary: List test cases for a project
+      description: Returns test cases ordered by last-seen result desc.
+      parameters:
+        - $ref: '#/components/parameters/ProjectId'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/TestNameQuery'
+        - $ref: '#/components/parameters/TestSuiteFilter'
+        - $ref: '#/components/parameters/TestStatusFilter'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TestCaseListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /projects/{projectId}/tests/{testCaseId}/history:
+    get:
+      tags: [Tests]
+      operationId: getTestHistory
+      summary: Get execution history for a test case
+      parameters:
+        - $ref: '#/components/parameters/ProjectId'
+        - $ref: '#/components/parameters/TestCaseId'
+        - $ref: '#/components/parameters/HistoryLimit'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TestCaseHistoryResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
 components:
   securitySchemes:
     ApiKeyAuth:
@@ -359,6 +406,48 @@ components:
       required: false
       schema:
         $ref: '#/components/schemas/RunStatus'
+
+    TestCaseId:
+      name: testCaseId
+      in: path
+      required: true
+      schema:
+        type: string
+        minLength: 1
+
+    TestNameQuery:
+      name: q
+      in: query
+      required: false
+      description: Filter test cases by name or externalId (substring match).
+      schema:
+        type: string
+
+    TestSuiteFilter:
+      name: suite
+      in: query
+      required: false
+      description: Filter test cases by suiteName (substring match).
+      schema:
+        type: string
+
+    TestStatusFilter:
+      name: status
+      in: query
+      required: false
+      description: Filter test cases by last-seen status.
+      schema:
+        $ref: '#/components/schemas/TestStatus'
+
+    HistoryLimit:
+      name: limit
+      in: query
+      required: false
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 200
+        default: 50
 
   responses:
     Unauthorized:
@@ -488,6 +577,11 @@ components:
     TestStatus:
       type: string
       enum: [PASSED, FAILED, SKIPPED, ERROR]
+
+    NullableTestStatus:
+      type: string
+      enum: [PASSED, FAILED, SKIPPED, ERROR]
+      nullable: true
 
     RunListItem:
       type: object
@@ -659,6 +753,91 @@ components:
           type: array
           items:
             type: string
+      additionalProperties: false
+
+    TestCaseListItem:
+      type: object
+      required: [id, externalId, name, tags, createdAt, lastStatus, lastSeenAt]
+      properties:
+        id:
+          type: string
+        externalId:
+          type: string
+        name:
+          type: string
+        suiteName:
+          type: string
+          nullable: true
+        filePath:
+          type: string
+          nullable: true
+        tags:
+          type: array
+          items:
+            type: string
+        createdAt:
+          type: string
+          format: date-time
+        lastStatus:
+          $ref: '#/components/schemas/NullableTestStatus'
+        lastSeenAt:
+          type: string
+          format: date-time
+          nullable: true
+      additionalProperties: false
+
+    TestCaseListResponse:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/TestCaseListItem'
+      additionalProperties: false
+
+    TestCaseHistoryItem:
+      type: object
+      required: [id, status, durationMs, createdAt, run]
+      properties:
+        id:
+          type: string
+        status:
+          $ref: '#/components/schemas/TestStatus'
+        durationMs:
+          type: integer
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        run:
+          type: object
+          required: [id, createdAt, status, branch, commitSha]
+          properties:
+            id:
+              type: string
+            createdAt:
+              type: string
+              format: date-time
+            status:
+              $ref: '#/components/schemas/RunStatus'
+            branch:
+              type: string
+              nullable: true
+            commitSha:
+              type: string
+              nullable: true
+          additionalProperties: false
+      additionalProperties: false
+
+    TestCaseHistoryResponse:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/TestCaseHistoryItem'
       additionalProperties: false
 
     RunResultItem:

--- a/web/src/components/layout/AppShell.tsx
+++ b/web/src/components/layout/AppShell.tsx
@@ -54,5 +54,3 @@ export function AppShell() {
 		</div>
 	);
 }
-// For debugging env vars, remove later!
-console.log(import.meta.env.VITE_API_URL);

--- a/web/src/gen/openapi.ts
+++ b/web/src/gen/openapi.ts
@@ -172,6 +172,43 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/projects/{projectId}/tests": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List test cases for a project
+         * @description Returns test cases ordered by last-seen result desc.
+         */
+        get: operations["listTests"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/projects/{projectId}/tests/{testCaseId}/history": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get execution history for a test case */
+        get: operations["getTestHistory"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -281,6 +318,40 @@ export interface components {
             suiteName?: string | null;
             tags: string[];
         };
+        TestCaseListItem: {
+            id: string;
+            externalId: string;
+            name: string;
+            suiteName?: string | null;
+            filePath?: string | null;
+            tags: string[];
+            /** Format: date-time */
+            createdAt: string;
+            lastStatus: components["schemas"]["TestStatus"] | null;
+            /** Format: date-time */
+            lastSeenAt: string | null;
+        };
+        TestCaseListResponse: {
+            items: components["schemas"]["TestCaseListItem"][];
+        };
+        TestCaseHistoryItem: {
+            id: string;
+            status: components["schemas"]["TestStatus"];
+            durationMs: number | null;
+            /** Format: date-time */
+            createdAt: string;
+            run: {
+                id: string;
+                /** Format: date-time */
+                createdAt: string;
+                status: components["schemas"]["RunStatus"];
+                branch: string | null;
+                commitSha: string | null;
+            };
+        };
+        TestCaseHistoryResponse: {
+            items: components["schemas"]["TestCaseHistoryItem"][];
+        };
         RunResultItem: {
             id: string;
             status: components["schemas"]["TestStatus"];
@@ -362,6 +433,14 @@ export interface components {
         /** @description Cursor pagination using the last seen run id. */
         Cursor: string;
         RunStatusFilter: components["schemas"]["RunStatus"];
+        TestCaseId: string;
+        /** @description Filter test cases by name or externalId (substring match). */
+        TestNameQuery: string;
+        /** @description Filter test cases by suiteName (substring match). */
+        TestSuiteFilter: string;
+        /** @description Filter test cases by last-seen status. */
+        TestStatusFilter: components["schemas"]["TestStatus"];
+        HistoryLimit: number;
     };
     requestBodies: never;
     headers: never;
@@ -699,6 +778,67 @@ export interface operations {
                 };
             };
             400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    listTests: {
+        parameters: {
+            query?: {
+                limit?: components["parameters"]["Limit"];
+                /** @description Filter test cases by name or externalId (substring match). */
+                q?: components["parameters"]["TestNameQuery"];
+                /** @description Filter test cases by suiteName (substring match). */
+                suite?: components["parameters"]["TestSuiteFilter"];
+                /** @description Filter test cases by last-seen status. */
+                status?: components["parameters"]["TestStatusFilter"];
+            };
+            header?: never;
+            path: {
+                /** @description Project slug or database id (implementation accepts both). */
+                projectId: components["parameters"]["ProjectId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TestCaseListResponse"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    getTestHistory: {
+        parameters: {
+            query?: {
+                limit?: components["parameters"]["HistoryLimit"];
+            };
+            header?: never;
+            path: {
+                /** @description Project slug or database id (implementation accepts both). */
+                projectId: components["parameters"]["ProjectId"];
+                testCaseId: components["parameters"]["TestCaseId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TestCaseHistoryResponse"];
+                };
+            };
             401: components["responses"]["Unauthorized"];
             404: components["responses"]["NotFound"];
         };

--- a/web/src/pages/TestsPage.tsx
+++ b/web/src/pages/TestsPage.tsx
@@ -1,8 +1,392 @@
+import * as React from 'react';
+import { useParams } from 'react-router-dom';
+
+import { useAuth } from '@/lib/useAuth';
+import {
+	ApiError,
+	listTests,
+	getTestHistory,
+	type TestCaseListItem,
+	type TestStatus,
+} from '@/lib/api';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from '@/components/ui/select';
+import { PageError, PageLoading } from '@/components/common/PageState';
+import { AuthRequiredCallout } from '@/components/common/AuthRequiredCallout';
+
+type StatusFilter = 'ALL' | TestStatus;
+
+function formatDate(iso: string) {
+	return new Date(iso).toLocaleString();
+}
+
+function testStatusVariant(
+	status: StatusFilter,
+): 'default' | 'secondary' | 'destructive' {
+	if (status === 'FAILED' || status === 'ERROR') return 'destructive';
+	if (status === 'PASSED') return 'default';
+	return 'secondary';
+}
+
+function testStatusLabel(status: StatusFilter) {
+	if (status === 'ALL') return 'All';
+	return status;
+}
+
 export function TestsPage() {
+	const { projectId } = useParams();
+	const pid = projectId ?? 'demo';
+	const { apiKey, hasApiKey } = useAuth();
+
+	const [items, setItems] = React.useState<TestCaseListItem[]>([]);
+	const [loading, setLoading] = React.useState(true);
+	const [error, setError] = React.useState<string | null>(null);
+	const [lastError, setLastError] = React.useState<unknown>(null);
+
+	const [q, setQ] = React.useState('');
+	const [suite, setSuite] = React.useState('');
+	const [status, setStatus] = React.useState<StatusFilter>('ALL');
+
+	const [selected, setSelected] = React.useState<TestCaseListItem | null>(null);
+	const [historyLoading, setHistoryLoading] = React.useState(false);
+	const [historyError, setHistoryError] = React.useState<string | null>(null);
+	const [history, setHistory] = React.useState<
+		Array<{
+			id: string;
+			status: TestStatus;
+			durationMs: number | null;
+			createdAt: string;
+			run: {
+				id: string;
+				createdAt: string;
+				status: string;
+				branch: string | null;
+				commitSha: string | null;
+			};
+		}>
+	>([]);
+
+	const refresh = React.useCallback(async () => {
+		if (!hasApiKey) {
+			setItems([]);
+			setSelected(null);
+			setLoading(false);
+			setError(null);
+			setLastError(null);
+			return;
+		}
+
+		setLoading(true);
+		setError(null);
+		setLastError(null);
+
+		try {
+			const data = await listTests(pid, {
+				limit: 100,
+				q: q.trim() ? q.trim() : undefined,
+				suite: suite.trim() ? suite.trim() : undefined,
+				status: status === 'ALL' ? undefined : status,
+			});
+			setItems(data.items);
+		} catch (e) {
+			setLastError(e);
+			setError(e instanceof Error ? e.message : 'Unknown error');
+		} finally {
+			setLoading(false);
+		}
+	}, [hasApiKey, pid, q, suite, status]);
+
+	React.useEffect(() => {
+		void refresh();
+	}, [refresh, apiKey]);
+
+	React.useEffect(() => {
+		async function loadHistory() {
+			if (!hasApiKey || !selected) return;
+			setHistoryLoading(true);
+			setHistoryError(null);
+			try {
+				const data = await getTestHistory(pid, selected.id, { limit: 50 });
+				setHistory(data.items);
+			} catch (e) {
+				setHistory([]);
+				if (e instanceof ApiError) setHistoryError(e.message);
+				else if (e instanceof Error) setHistoryError(e.message);
+				else setHistoryError('Failed to load history');
+			} finally {
+				setHistoryLoading(false);
+			}
+		}
+		void loadHistory();
+	}, [hasApiKey, pid, selected]);
+
+	const showAuthCallout =
+		!hasApiKey || (lastError instanceof ApiError && lastError.status === 401);
+
+	const stats = React.useMemo(() => {
+		let passed = 0,
+			failed = 0,
+			skipped = 0,
+			error = 0;
+		let durationTotal = 0;
+		let durationCount = 0;
+
+		for (const h of history) {
+			if (h.status === 'PASSED') passed++;
+			else if (h.status === 'FAILED') failed++;
+			else if (h.status === 'SKIPPED') skipped++;
+			else error++;
+
+			if (typeof h.durationMs === 'number') {
+				durationTotal += h.durationMs;
+				durationCount++;
+			}
+		}
+
+		const total = passed + failed + skipped + error;
+		const passRate = total ? Math.round((passed / total) * 100) : 0;
+		const avgDurationMs = durationCount
+			? Math.round(durationTotal / durationCount)
+			: null;
+
+		return { passed, failed, skipped, error, total, passRate, avgDurationMs };
+	}, [history]);
+
 	return (
-		<div>
-			<h1>Tests</h1>
-			<p>Tests explorer coming soon.</p>
+		<div className='space-y-6'>
+			<div>
+				<h1 className='text-xl font-semibold'>Tests</h1>
+				<p className='text-sm text-muted-foreground'>
+					Explore test cases and their recent execution history.
+				</p>
+			</div>
+
+			{showAuthCallout ? <AuthRequiredCallout /> : null}
+
+			<div className='grid gap-3 md:grid-cols-3'>
+				<div className='space-y-1'>
+					<label className='text-xs font-medium' htmlFor='tests-q'>
+						Name / External ID
+					</label>
+					<Input
+						id='tests-q'
+						placeholder='Search…'
+						value={q}
+						onChange={(e) => setQ(e.target.value)}
+						disabled={!hasApiKey}
+					/>
+				</div>
+
+				<div className='space-y-1'>
+					<label className='text-xs font-medium' htmlFor='tests-suite'>
+						Suite
+					</label>
+					<Input
+						id='tests-suite'
+						placeholder='e.g. auth, checkout…'
+						value={suite}
+						onChange={(e) => setSuite(e.target.value)}
+						disabled={!hasApiKey}
+					/>
+				</div>
+
+				<div className='space-y-1'>
+					<label className='text-xs font-medium'>Last Status</label>
+					<Select
+						value={status}
+						onValueChange={(v) => setStatus(v as StatusFilter)}
+						disabled={!hasApiKey}>
+						<SelectTrigger>
+							<SelectValue placeholder='All' />
+						</SelectTrigger>
+						<SelectContent>
+							<SelectItem value='ALL'>All</SelectItem>
+							<SelectItem value='PASSED'>Passed</SelectItem>
+							<SelectItem value='FAILED'>Failed</SelectItem>
+							<SelectItem value='SKIPPED'>Skipped</SelectItem>
+							<SelectItem value='ERROR'>Error</SelectItem>
+						</SelectContent>
+					</Select>
+				</div>
+			</div>
+
+			<div className='flex items-center gap-2'>
+				<Button
+					variant='secondary'
+					onClick={() => void refresh()}
+					disabled={!hasApiKey}>
+					Refresh
+				</Button>
+				<Button
+					variant='outline'
+					onClick={() => {
+						setQ('');
+						setSuite('');
+						setStatus('ALL');
+					}}
+					disabled={!hasApiKey}>
+					Clear filters
+				</Button>
+			</div>
+
+			{error ? (
+				<PageError
+					title='Tests'
+					message={error}
+					onRetry={() => void refresh()}
+				/>
+			) : loading ? (
+				<PageLoading title='Tests' />
+			) : !hasApiKey ? (
+				<div className='rounded-md border p-6 text-sm text-muted-foreground'>
+					Set an API key in Settings to view tests.
+				</div>
+			) : items.length === 0 ? (
+				<div className='rounded-md border p-6 text-sm text-muted-foreground'>
+					No tests found. Ingest a run with results to populate test cases.
+				</div>
+			) : (
+				<div className='grid gap-4 lg:grid-cols-[1.2fr,0.8fr]'>
+					<div className='overflow-hidden rounded-md border'>
+						<div className='grid grid-cols-12 gap-2 bg-muted/40 px-4 py-2 text-xs font-medium text-muted-foreground'>
+							<div className='col-span-5'>Name</div>
+							<div className='col-span-3'>Suite</div>
+							<div className='col-span-2'>Last status</div>
+							<div className='col-span-2 text-right'>Last seen</div>
+						</div>
+
+						<div className='divide-y'>
+							{items.map((t) => {
+								const isSelected = selected?.id === t.id;
+								const last = (t as any).lastStatus as TestStatus | null;
+								return (
+									<div
+										key={t.id}
+										tabIndex={0}
+										role='button'
+										onClick={() => setSelected(t)}
+										onKeyDown={(e) => {
+											if (e.key === 'Enter' || e.key === ' ') {
+												e.preventDefault();
+												setSelected(t);
+											}
+										}}
+										className={
+											'grid grid-cols-12 items-center gap-2 px-4 py-3 text-sm cursor-pointer hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring ' +
+											(isSelected ? 'bg-muted/30' : '')
+										}>
+										<div className='col-span-5 font-medium truncate'>
+											{t.name}
+											<div className='text-[11px] text-muted-foreground truncate'>
+												{t.externalId}
+											</div>
+										</div>
+										<div className='col-span-3 text-muted-foreground truncate'>
+											{t.suiteName ?? '—'}
+										</div>
+										<div className='col-span-2'>
+											<Badge
+												variant={testStatusVariant(
+													(last ?? 'ALL') as StatusFilter,
+												)}>
+												{last ? last : '—'}
+											</Badge>
+										</div>
+										<div className='col-span-2 text-right text-muted-foreground text-xs'>
+											{t.lastSeenAt ? formatDate(t.lastSeenAt) : '—'}
+										</div>
+									</div>
+								);
+							})}
+						</div>
+					</div>
+
+					<div className='rounded-md border p-4 space-y-3'>
+						<h2 className='text-sm font-medium'>Details</h2>
+						{!selected ? (
+							<p className='text-sm text-muted-foreground'>
+								Select a test to see its recent history.
+							</p>
+						) : (
+							<div className='space-y-3'>
+								<div className='space-y-1'>
+									<div className='text-sm font-medium'>{selected.name}</div>
+									<div className='text-xs text-muted-foreground break-all'>
+										{selected.externalId}
+									</div>
+									<div className='text-xs text-muted-foreground'>
+										Suite: {selected.suiteName ?? '—'}
+									</div>
+								</div>
+
+								{historyError ? (
+									<p className='text-xs text-destructive'>{historyError}</p>
+								) : historyLoading ? (
+									<p className='text-sm text-muted-foreground'>
+										Loading history…
+									</p>
+								) : history.length === 0 ? (
+									<p className='text-sm text-muted-foreground'>
+										No history yet.
+									</p>
+								) : (
+									<div className='space-y-2'>
+										<div className='flex flex-wrap gap-2'>
+											<Badge variant='secondary'>Last {stats.total}</Badge>
+											<Badge variant='default'>
+												Pass rate {stats.passRate}%
+											</Badge>
+											<Badge variant='destructive'>
+												Failed {stats.failed + stats.error}
+											</Badge>
+											<Badge variant='secondary'>Skipped {stats.skipped}</Badge>
+											{stats.avgDurationMs != null ? (
+												<Badge variant='outline'>
+													Avg {stats.avgDurationMs}ms
+												</Badge>
+											) : null}
+										</div>
+
+										<div className='space-y-2'>
+											<div className='text-xs text-muted-foreground'>
+												Recent results
+											</div>
+											<div className='space-y-1'>
+												{history.slice(0, 12).map((h) => (
+													<div
+														key={h.id}
+														className='flex items-center justify-between gap-2 text-xs'>
+														<div className='flex items-center gap-2 min-w-0'>
+															<Badge variant={testStatusVariant(h.status)}>
+																{h.status}
+															</Badge>
+															<span className='text-muted-foreground truncate'>
+																{formatDate(h.createdAt)}
+															</span>
+														</div>
+														<div className='text-muted-foreground'>
+															{h.durationMs != null ? `${h.durationMs}ms` : '—'}
+														</div>
+													</div>
+												))}
+											</div>
+										</div>
+									</div>
+								)}
+							</div>
+						)}
+					</div>
+				</div>
+			)}
 		</div>
 	);
 }


### PR DESCRIPTION
- Add API routes to list test cases and fetch per- test history
- Extend OpenAPI contract and regenerate web OpenAPI types
- Add typed web client calls for tests (listTests, getTestHistory)
- Implement Tests page UI with filters, selection, history panel and stats
- Remove debug env log; align API base URL env var handling
- Fix OpenAPI nullable schema so API boots with validation enabled