### PR TITLE
Refine analytics visuals and status palette

### DIFF
--- a/web/src/pages/AnalyticsPage.tsx
+++ b/web/src/pages/AnalyticsPage.tsx
@@ -34,6 +34,7 @@ import {
 	BarChart,
 	CartesianGrid,
 	Cell,
+	Label,
 	Pie,
 	PieChart,
 	XAxis,
@@ -85,27 +86,27 @@ function truncateLabel(label: string) {
 const chartConfig: ChartConfig = {
 	passed: {
 		label: 'Passed',
-		theme: { light: 'var(--chart-2-40)', dark: 'var(--chart-2-40)' },
+		theme: { light: 'var(--test-passed)', dark: 'var(--test-passed)' },
 	},
 	failed: {
 		label: 'Failed',
-		theme: { light: 'var(--chart-5-40)', dark: 'var(--chart-5-40)' },
+		theme: { light: 'var(--test-failed)', dark: 'var(--test-failed)' },
 	},
 	error: {
 		label: 'Error',
-		theme: { light: 'var(--chart-4-40)', dark: 'var(--chart-4-40)' },
+		theme: { light: 'var(--test-error)', dark: 'var(--test-error)' },
 	},
 	skipped: {
 		label: 'Skipped',
-		theme: { light: 'var(--chart-3-40)', dark: 'var(--chart-3-40)' },
+		theme: { light: 'var(--test-skipped)', dark: 'var(--test-skipped)' },
 	},
 	avg: {
 		label: 'Avg (ms)',
-		theme: { light: 'var(--chart-1-40)', dark: 'var(--chart-1-40)' },
+		theme: { light: 'var(--test-slow)', dark: 'var(--test-slow)' },
 	},
 	max: {
 		label: 'Max (ms)',
-		theme: { light: 'var(--chart-3-40)', dark: 'var(--chart-3-40)' },
+		theme: { light: 'var(--test-paused)', dark: 'var(--test-paused)' },
 	},
 };
 
@@ -166,6 +167,9 @@ export function AnalyticsPage() {
 			{ passed: 0, failed: 0, error: 0, skipped: 0 },
 		);
 	}, [timeseriesChartData]);
+
+	const totalTests =
+		totals.passed + totals.failed + totals.error + totals.skipped;
 
 	const pieData = useMemo(
 		() =>
@@ -347,7 +351,7 @@ export function AnalyticsPage() {
 				<Card className='bg-muted text-foreground'>
 					<CardHeader className='flex flex-row items-start justify-between gap-4 space-y-0'>
 						<div>
-							<CardTitle>Failures over time</CardTitle>
+							<CardTitle>Test results over time</CardTitle>
 							<CardDescription>Daily totals by status</CardDescription>
 						</div>
 						{viewMode === 'chart' ? (
@@ -460,30 +464,33 @@ export function AnalyticsPage() {
 													dataKey='passed'
 													stackId='a'
 													fill='var(--color-passed)'
-													stroke='var(--chart-2-65)'
+													stroke='var(--color-passed)'
 													strokeWidth={1}
-													radius={[3, 3, 0, 0]}
+													radius={[4, 4, 0, 0]}
 												/>
 												<Bar
 													dataKey='failed'
 													stackId='a'
 													fill='var(--color-failed)'
-													stroke='var(--chart-5-65)'
+													stroke='var(--color-failed)'
 													strokeWidth={1}
+													radius={[4, 4, 0, 0]}
 												/>
 												<Bar
 													dataKey='error'
 													stackId='a'
 													fill='var(--color-error)'
-													stroke='var(--chart-4-65)'
+													stroke='var(--color-error)'
 													strokeWidth={1}
+													radius={[4, 4, 0, 0]}
 												/>
 												<Bar
 													dataKey='skipped'
 													stackId='a'
 													fill='var(--color-skipped)'
-													stroke='var(--chart-3-65)'
+													stroke='var(--color-skipped)'
 													strokeWidth={1}
+													radius={[4, 4, 0, 0]}
 												/>
 											</BarChart>
 										) : (
@@ -611,7 +618,7 @@ export function AnalyticsPage() {
 													dataKey='passed'
 													stackId='a'
 													fill='url(#fillPassed)'
-													stroke='var(--chart-2-65)'
+													stroke='var(--color-passed)'
 													strokeWidth={1}
 													type='monotone'
 												/>
@@ -619,7 +626,7 @@ export function AnalyticsPage() {
 													dataKey='failed'
 													stackId='a'
 													fill='url(#fillFailed)'
-													stroke='var(--chart-5-65)'
+													stroke='var(--color-failed)'
 													strokeWidth={1}
 													type='monotone'
 												/>
@@ -627,7 +634,7 @@ export function AnalyticsPage() {
 													dataKey='error'
 													stackId='a'
 													fill='url(#fillError)'
-													stroke='var(--chart-4-65)'
+													stroke='var(--color-error)'
 													strokeWidth={1}
 													type='monotone'
 												/>
@@ -635,7 +642,7 @@ export function AnalyticsPage() {
 													dataKey='skipped'
 													stackId='a'
 													fill='url(#fillSkipped)'
-													stroke='var(--chart-3-65)'
+													stroke='var(--color-skipped)'
 													strokeWidth={1}
 													type='monotone'
 												/>
@@ -653,8 +660,8 @@ export function AnalyticsPage() {
 				</Card>
 
 				<Card className='bg-muted text-foreground'>
-					<CardHeader>
-						<CardTitle>Failures breakdown</CardTitle>
+					<CardHeader className='space-y-0'>
+						<CardTitle>Test results overview</CardTitle>
 						<CardDescription>Totals by status</CardDescription>
 					</CardHeader>
 					<CardContent>
@@ -699,6 +706,36 @@ export function AnalyticsPage() {
 												outerRadius={90}
 												paddingAngle={4}
 												stroke='none'>
+												<Label
+													content={({ viewBox }) => {
+														if (!viewBox || !('cx' in viewBox)) return null;
+														const { cx, cy } = viewBox as {
+															cx: number;
+															cy: number;
+														};
+														const yOffset = cy - 14;
+														return (
+															<g transform={`translate(${cx}, ${yOffset})`}>
+																<text
+																	textAnchor='middle'
+																	dominantBaseline='middle'>
+																	<tspan
+																		x={0}
+																		dy='0'
+																		className='fill-foreground text-2xl font-semibold'>
+																		{formatCount(totalTests)}
+																	</tspan>
+																	<tspan
+																		x={0}
+																		dy='18'
+																		className='fill-muted-foreground text-xs'>
+																		tests
+																	</tspan>
+																</text>
+															</g>
+														);
+													}}
+												/>
 												{pieData.map((entry) => (
 													<Cell
 														key={entry.key}
@@ -722,7 +759,7 @@ export function AnalyticsPage() {
 
 			<div className='grid gap-6 lg:grid-cols-2'>
 				<Card className='bg-muted text-foreground'>
-					<CardHeader>
+					<CardHeader className='space-y-0'>
 						<CardTitle>Slowest tests</CardTitle>
 						<CardDescription>Top {limit} by avg duration</CardDescription>
 					</CardHeader>
@@ -818,7 +855,7 @@ export function AnalyticsPage() {
 											<Bar
 												dataKey='avg'
 												fill='var(--color-avg)'
-												stroke='var(--chart-1-65)'
+												stroke='var(--color-avg)'
 												strokeWidth={1}
 												name='Avg (ms)'
 												radius={[0, 4, 4, 0]}
@@ -826,9 +863,10 @@ export function AnalyticsPage() {
 											<Bar
 												dataKey='max'
 												fill='var(--color-max)'
-												stroke='var(--chart-3-65)'
+												stroke='var(--color-max)'
 												strokeWidth={1}
 												name='Max (ms)'
+												radius={[0, 4, 4, 0]}
 											/>
 										</BarChart>
 									</ChartContainer>
@@ -843,7 +881,7 @@ export function AnalyticsPage() {
 				</Card>
 
 				<Card className='bg-muted text-foreground'>
-					<CardHeader>
+					<CardHeader className='space-y-0'>
 						<CardTitle>Most failing tests</CardTitle>
 						<CardDescription>Top {limit} by fail/error count</CardDescription>
 					</CardHeader>
@@ -934,7 +972,7 @@ export function AnalyticsPage() {
 												dataKey='failed'
 												stackId='a'
 												fill='var(--color-failed)'
-												stroke='var(--chart-5-65)'
+												stroke='var(--color-failed)'
 												strokeWidth={1}
 												name='Failed'
 												radius={[0, 4, 4, 0]}
@@ -943,9 +981,10 @@ export function AnalyticsPage() {
 												dataKey='error'
 												stackId='a'
 												fill='var(--color-error)'
-												stroke='var(--chart-4-65)'
+												stroke='var(--color-error)'
 												strokeWidth={1}
 												name='Error'
+												radius={[0, 4, 4, 0]}
 											/>
 										</BarChart>
 									</ChartContainer>

--- a/web/src/pages/RunDetailsPage.tsx
+++ b/web/src/pages/RunDetailsPage.tsx
@@ -25,34 +25,34 @@ import { PageError } from '@/components/common/PageState';
 import { AuthRequiredCallout } from '@/components/common/AuthRequiredCallout';
 import { useAuth } from '@/lib/useAuth';
 
-function runStatusBadgeVariant(status: RunDetails['status']) {
+function runStatusBadgeClass(status: RunDetails['status']) {
 	switch (status) {
 		case 'COMPLETED':
-			return 'default';
+			return 'border-[color:var(--test-passed)] text-[color:var(--test-passed)] bg-[color-mix(in_oklch,var(--test-passed)_16%,transparent)]';
 		case 'FAILED':
-			return 'destructive';
+			return 'border-[color:var(--test-failed)] text-[color:var(--test-failed)] bg-[color-mix(in_oklch,var(--test-failed)_16%,transparent)]';
 		case 'RUNNING':
 		case 'QUEUED':
-			return 'secondary';
+			return 'border-[color:var(--test-paused)] text-[color:var(--test-paused)] bg-[color-mix(in_oklch,var(--test-paused)_16%,transparent)]';
 		case 'CANCELED':
-			return 'outline';
+			return 'border-[color:var(--test-skipped)] text-[color:var(--test-skipped)] bg-[color-mix(in_oklch,var(--test-skipped)_16%,transparent)]';
 		default:
-			return 'secondary';
+			return 'border-muted text-muted-foreground bg-transparent';
 	}
 }
 
-function testStatusBadgeVariant(status: TestStatus) {
+function testStatusBadgeClass(status: TestStatus) {
 	switch (status) {
 		case 'PASSED':
-			return 'default';
+			return 'border-[color:var(--test-passed)] text-[color:var(--test-passed)] bg-[color-mix(in_oklch,var(--test-passed)_16%,transparent)]';
 		case 'FAILED':
-			return 'destructive';
-		case 'SKIPPED':
-			return 'secondary';
+			return 'border-[color:var(--test-failed)] text-[color:var(--test-failed)] bg-[color-mix(in_oklch,var(--test-failed)_16%,transparent)]';
 		case 'ERROR':
-			return 'destructive';
+			return 'border-[color:var(--test-error)] text-[color:var(--test-error)] bg-[color-mix(in_oklch,var(--test-error)_16%,transparent)]';
+		case 'SKIPPED':
+			return 'border-[color:var(--test-skipped)] text-[color:var(--test-skipped)] bg-[color-mix(in_oklch,var(--test-skipped)_16%,transparent)]';
 		default:
-			return 'secondary';
+			return 'border-muted text-muted-foreground bg-transparent';
 	}
 }
 
@@ -220,7 +220,9 @@ export function RunDetailsPage() {
 								{run.id}
 							</span>
 						</h1>
-						<Badge variant={runStatusBadgeVariant(run.status)}>
+						<Badge
+							variant='outline'
+							className={runStatusBadgeClass(run.status)}>
 							{run.status}
 						</Badge>
 					</div>
@@ -326,7 +328,9 @@ export function RunDetailsPage() {
 									<div key={r.id} className='px-4 py-3'>
 										<div className='grid grid-cols-12 items-start gap-2'>
 											<div className='col-span-2'>
-												<Badge variant={testStatusBadgeVariant(r.status)}>
+												<Badge
+													variant='outline'
+													className={testStatusBadgeClass(r.status)}>
 													{r.status}
 												</Badge>
 											</div>

--- a/web/src/pages/RunsPage.tsx
+++ b/web/src/pages/RunsPage.tsx
@@ -26,12 +26,20 @@ function formatDate(iso: string) {
 	return d.toLocaleString();
 }
 
-function statusVariant(
-	status: RunListItem['status'],
-): 'default' | 'secondary' | 'destructive' {
-	if (status === 'FAILED') return 'destructive';
-	if (status === 'COMPLETED') return 'default';
-	return 'secondary';
+function runStatusBadgeClass(status: RunListItem['status']) {
+	switch (status) {
+		case 'COMPLETED':
+			return 'border-[color:var(--test-passed)] text-[color:var(--test-passed)] bg-[color-mix(in_oklch,var(--test-passed)_16%,transparent)]';
+		case 'FAILED':
+			return 'border-[color:var(--test-failed)] text-[color:var(--test-failed)] bg-[color-mix(in_oklch,var(--test-failed)_16%,transparent)]';
+		case 'RUNNING':
+		case 'QUEUED':
+			return 'border-[color:var(--test-paused)] text-[color:var(--test-paused)] bg-[color-mix(in_oklch,var(--test-paused)_16%,transparent)]';
+		case 'CANCELED':
+			return 'border-[color:var(--test-skipped)] text-[color:var(--test-skipped)] bg-[color-mix(in_oklch,var(--test-skipped)_16%,transparent)]';
+		default:
+			return 'border-muted text-muted-foreground bg-transparent';
+	}
 }
 
 type StatusFilter = 'ALL' | RunStatus;
@@ -529,7 +537,11 @@ export function RunsPage() {
 									<div className='col-span-3'>{formatDate(r.createdAt)}</div>
 
 									<div className='col-span-2'>
-										<Badge variant={statusVariant(r.status)}>{r.status}</Badge>
+										<Badge
+											variant='outline'
+											className={runStatusBadgeClass(r.status)}>
+											{r.status}
+										</Badge>
 									</div>
 
 									<div className='col-span-3 truncate text-muted-foreground'>

--- a/web/src/pages/TestsPage.tsx
+++ b/web/src/pages/TestsPage.tsx
@@ -37,12 +37,19 @@ function formatDate(iso: string) {
 	return new Date(iso).toLocaleString();
 }
 
-function testStatusVariant(
-	status: StatusFilter,
-): 'default' | 'secondary' | 'destructive' {
-	if (status === 'FAILED' || status === 'ERROR') return 'destructive';
-	if (status === 'PASSED') return 'default';
-	return 'secondary';
+function testStatusBadgeClass(status?: StatusFilter | null) {
+	switch (status) {
+		case 'PASSED':
+			return 'border-[color:var(--test-passed)] text-[color:var(--test-passed)] bg-[color-mix(in_oklch,var(--test-passed)_16%,transparent)]';
+		case 'FAILED':
+			return 'border-[color:var(--test-failed)] text-[color:var(--test-failed)] bg-[color-mix(in_oklch,var(--test-failed)_16%,transparent)]';
+		case 'ERROR':
+			return 'border-[color:var(--test-error)] text-[color:var(--test-error)] bg-[color-mix(in_oklch,var(--test-error)_16%,transparent)]';
+		case 'SKIPPED':
+			return 'border-[color:var(--test-skipped)] text-[color:var(--test-skipped)] bg-[color-mix(in_oklch,var(--test-skipped)_16%,transparent)]';
+		default:
+			return 'border-muted text-muted-foreground bg-transparent';
+	}
 }
 
 export function TestsPage() {
@@ -185,7 +192,7 @@ export function TestsPage() {
 	const passRateChartConfig: ChartConfig = {
 		passed: {
 			label: 'Passed',
-			theme: { light: 'var(--chart-2-40)', dark: 'var(--chart-2-40)' },
+			theme: { light: 'var(--test-passed)', dark: 'var(--test-passed)' },
 		},
 	};
 
@@ -359,7 +366,8 @@ export function TestsPage() {
 										</div>
 										<div className='col-span-2'>
 											<Badge
-												variant={testStatusVariant(
+												variant='outline'
+												className={testStatusBadgeClass(
 													(last ?? 'ALL') as StatusFilter,
 												)}>
 												{last ? last : '—'}
@@ -472,10 +480,16 @@ export function TestsPage() {
 											<Badge variant='default'>
 												Pass rate {stats.passRate}%
 											</Badge>
-											<Badge variant='destructive'>
+											<Badge
+												variant='outline'
+												className={testStatusBadgeClass('FAILED')}>
 												Failed {stats.failed + stats.error}
 											</Badge>
-											<Badge variant='secondary'>Skipped {stats.skipped}</Badge>
+											<Badge
+												variant='outline'
+												className={testStatusBadgeClass('SKIPPED')}>
+												Skipped {stats.skipped}
+											</Badge>
 											{stats.avgDurationMs != null ? (
 												<Badge variant='outline'>
 													Avg {stats.avgDurationMs}ms
@@ -493,7 +507,9 @@ export function TestsPage() {
 														key={h.id}
 														className='flex items-center justify-between gap-2 text-xs'>
 														<div className='flex items-center gap-2 min-w-0'>
-															<Badge variant={testStatusVariant(h.status)}>
+															<Badge
+																variant='outline'
+																className={testStatusBadgeClass(h.status)}>
 																{h.status}
 															</Badge>
 															<span className='text-muted-foreground truncate'>

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -52,6 +52,12 @@
 	--chart-3-40: oklch(0.398 0.07 227.392 / 0.4);
 	--chart-4-40: oklch(0.828 0.189 84.429 / 0.4);
 	--chart-5-40: oklch(0.769 0.188 70.08 / 0.4);
+	--test-passed: #88c895;
+	--test-failed: #d05c5b;
+	--test-error: #de8177;
+	--test-skipped: oklch(0.72 0.02 260);
+	--test-paused: oklch(0.8 0.16 80);
+	--test-slow: oklch(0.75 0.19 50);
 	--sidebar: oklch(0.984 0.003 247.858);
 	--sidebar-foreground: oklch(0.129 0.042 264.695);
 	--sidebar-primary: oklch(0.208 0.042 265.755);
@@ -141,6 +147,12 @@ body {
 	--chart-3-40: oklch(0.769 0.188 70.08 / 0.4);
 	--chart-4-40: oklch(0.627 0.265 303.9 / 0.4);
 	--chart-5-40: oklch(0.645 0.246 16.439 / 0.4);
+	--test-passed: #88c895;
+	--test-failed: #d05c5b;
+	--test-error: #de8177;
+	--test-skipped: oklch(0.62 0.02 260);
+	--test-paused: oklch(0.85 0.16 80);
+	--test-slow: oklch(0.8 0.2 50);
 	--sidebar: oklch(0.208 0.042 265.755);
 	--sidebar-foreground: oklch(0.984 0.003 247.858);
 	--sidebar-primary: oklch(0.488 0.243 264.376);


### PR DESCRIPTION
- Update test-status colors (passed/failed/error) in theme variables
- Apply status palette to run/test badges and pass-rate chart
- Rename analytics sections to “Test results” wording
- Unify bar rounding, with horizontal charts rounding right-side corners
- Add donut center total label and fine-tune its vertical alignment
- Tighten title/description spacing for Slowest/Most failing cards